### PR TITLE
Support custom url scheme suffix

### DIFF
--- a/TwitterCore/TwitterCore/Networking/TWTRAuthConfig.h
+++ b/TwitterCore/TwitterCore/Networking/TWTRAuthConfig.h
@@ -32,6 +32,10 @@ NS_ASSUME_NONNULL_BEGIN
  *  The consumer secret of the Twitter application.
  */
 @property (nonatomic, copy, readonly) NSString *consumerSecret;
+/**
+ *  The custom suffix for callback url scheme.
+ */
+@property (nonatomic, copy, readonly, nullable) NSString *urlSchemeSuffix;
 
 /**
  *  Returns an `TWTRAuthConfig` object initialized by copying the values from the consumer key and consumer secret.
@@ -40,6 +44,15 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param consumerSecret The consumer secret.
  */
 - (instancetype)initWithConsumerKey:(NSString *)consumerKey consumerSecret:(NSString *)consumerSecret;
+
+/**
+ *  Returns an `TWTRAuthConfig` object initialized by copying the values from the consumer key and consumer secret.
+ *
+ *  @param consumerKey The consumer key.
+ *  @param consumerSecret The consumer secret.
+ *  @param urlSchemeSuffix The custom url scheme suffix.
+ */
+- (instancetype)initWithConsumerKey:(NSString *)consumerKey consumerSecret:(NSString *)consumerSecret urlSchemeSuffix:(nullable NSString *)urlSchemeSuffix;
 
 /**
  *  Unavailable. Use `initWithConsumerKey:consumerSecret:` instead.

--- a/TwitterCore/TwitterCore/Networking/TWTRAuthConfig.m
+++ b/TwitterCore/TwitterCore/Networking/TWTRAuthConfig.m
@@ -21,6 +21,7 @@
 
 @property (nonatomic, copy, readwrite) NSString *consumerKey;
 @property (nonatomic, copy, readwrite) NSString *consumerSecret;
+@property (nonatomic, copy, readwrite, nullable) NSString *urlSchemeSuffix;
 
 @end
 
@@ -28,11 +29,17 @@
 
 - (instancetype)initWithConsumerKey:(NSString *)consumerKey consumerSecret:(NSString *)consumerSecret
 {
+    return [self initWithConsumerKey:consumerKey consumerSecret:consumerSecret urlSchemeSuffix:nil];
+}
+
+- (instancetype)initWithConsumerKey:(NSString *)consumerKey consumerSecret:(NSString *)consumerSecret urlSchemeSuffix:(nullable NSString *)urlSchemeSuffix
+{
     NSParameterAssert(consumerKey);
     NSParameterAssert(consumerSecret);
     if ((self = [super init])) {
         _consumerKey = [consumerKey copy];
         _consumerSecret = [consumerSecret copy];
+        _urlSchemeSuffix = [urlSchemeSuffix copy];
     }
     return self;
 }
@@ -41,14 +48,16 @@
 {
     NSString *key = [coder decodeObjectForKey:@"consumerKey"];
     NSString *secret = [coder decodeObjectForKey:@"consumerSecret"];
+    NSString *urlSchemeSuffix = [coder decodeObjectForKey:@"urlSchemeSuffix"];
 
-    return [self initWithConsumerKey:key consumerSecret:secret];
+    return [self initWithConsumerKey:key consumerSecret:secret urlSchemeSuffix:urlSchemeSuffix];
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder
 {
     [coder encodeObject:self.consumerKey forKey:@"consumerKey"];
     [coder encodeObject:self.consumerSecret forKey:@"consumerSecret"];
+    [coder encodeObject:self.urlSchemeSuffix forKey:@"urlSchemeSuffix"];
 }
 
 - (BOOL)isEqual:(id)object
@@ -61,7 +70,14 @@
 
 - (BOOL)isEqualToAuthConfig:(TWTRAuthConfig *)otherAuthConfig
 {
-    return [self.consumerKey isEqualToString:otherAuthConfig.consumerKey] && [self.consumerSecret isEqualToString:otherAuthConfig.consumerSecret];
+    if (self.urlSchemeSuffix == nil && otherAuthConfig.urlSchemeSuffix == nil) {
+        return [self.consumerKey isEqualToString:otherAuthConfig.consumerKey]
+        && [self.consumerSecret isEqualToString:otherAuthConfig.consumerSecret];
+    } else {
+        return [self.urlSchemeSuffix isEqualToString:otherAuthConfig.urlSchemeSuffix]
+        && [self.consumerKey isEqualToString:otherAuthConfig.consumerKey]
+        && [self.consumerSecret isEqualToString:otherAuthConfig.consumerSecret];
+    }
 }
 
 - (NSUInteger)hash

--- a/TwitterKit/TwitterKit.xcodeproj/project.pbxproj
+++ b/TwitterKit/TwitterKit.xcodeproj/project.pbxproj
@@ -3164,6 +3164,7 @@
 			baseConfigurationReference = DB2241791C3DA603008A6DC7 /* TwitterKitTests.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = NO;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3183,6 +3184,7 @@
 			baseConfigurationReference = DB2241791C3DA603008A6DC7 /* TwitterKitTests.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = NO;
 				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/TwitterKit/TwitterKit/Social/Identity/TWTRLoginURLParser.m
+++ b/TwitterKit/TwitterKit/Social/Identity/TWTRLoginURLParser.m
@@ -36,7 +36,11 @@
 - (instancetype)initWithAuthConfig:(TWTRAuthConfig *)config
 {
     if (self = [super init]) {
-        self.twitterKitURLScheme = [NSString stringWithFormat:@"twitterkit-%@", config.consumerKey];
+        if (config.urlSchemeSuffix == nil) {
+            self.twitterKitURLScheme = [NSString stringWithFormat:@"twitterkit-%@", config.consumerKey];
+        } else {
+            self.twitterKitURLScheme = [NSString stringWithFormat:@"twitterkit-%@%@", config.consumerKey, config.urlSchemeSuffix];
+        }
         self.twitterAuthURL = [NSString stringWithFormat:@"twitterauth://authorize?consumer_key=%@&consumer_secret=%@&oauth_callback=%@", config.consumerKey, config.consumerSecret, self.twitterKitURLScheme];
     }
     return self;

--- a/TwitterKit/TwitterKit/Social/Syndication/Models/TWTRTweet.m
+++ b/TwitterKit/TwitterKit/Social/Syndication/Models/TWTRTweet.m
@@ -254,7 +254,7 @@ NSString *const TWTRTweetPerspectivalUserID = @"perspectival_user_id";
 {
     TWTRParameterAssertOrReturnValue([IDString length] > 0, nil);
 
-    return [NSString stringWithFormat:@"%@:%zd:%@:%@", NSStringFromClass([self class]), [[self class] version], perspective ?: @"", IDString];
+    return [NSString stringWithFormat:@"%@:%ld:%@:%@", NSStringFromClass([self class]), (long)[[self class] version], perspective ?: @"", IDString];
 }
 
 #pragma mark - JSON Validating

--- a/TwitterKit/TwitterKit/TWTRTwitter.h
+++ b/TwitterKit/TwitterKit/TWTRTwitter.h
@@ -55,7 +55,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)startWithConsumerKey:(NSString *)consumerKey consumerSecret:(NSString *)consumerSecret;
 
 /**
- *  Start Twitter with a consumer key, secret, and keychain access group. See -[TWTRTwitter startWithConsumerKey:consumerSecret:]
+ *  Start Twitter with your consumer key and secret. These will override any credentials
+ *  present in your applications Info.plist.
+ *
+ *  @param consumerKey    Your Twitter application's consumer key.
+ *  @param consumerSecret Your Twitter application's consumer secret.
+ *  @parama urlSchemeSuffix Custom suffix for callback url scheme
+ */
+- (void)startWithConsumerKey:(NSString *)consumerKey consumerSecret:(NSString *)consumerSecret urlSchemeSuffix:(nullable NSString *)urlSchemeSuffix;
+
+/**
+ *  Start Twitter with a consumer key, secret, and keychain access group. See -[TWTRTwitter startWithConsumerKey:consumerSecret:urlSchemeSuffix:]
  *
  *  @param consumerKey    Your Twitter application's consumer key.
  *  @param consumerSecret Your Twitter application's consumer secret.
@@ -66,6 +76,20 @@ NS_ASSUME_NONNULL_BEGIN
  *  using TwitterKit with an app extension.
  */
 - (void)startWithConsumerKey:(NSString *)consumerKey consumerSecret:(NSString *)consumerSecret accessGroup:(nullable NSString *)accessGroup;
+
+/**
+ *  Start Twitter with a consumer key, secret, and keychain access group. See -[TWTRTwitter startWithConsumerKey:consumerSecret:urlSchemeSuffix:]
+ *
+ *  @param consumerKey    Your Twitter application's consumer key.
+ *  @param consumerSecret Your Twitter application's consumer secret.
+ *  @param urlSchemeSuffix Custom suffix for callback url scheme
+ *  @param accessGroup    An optional keychain access group to apply to session objects stored in the keychain.
+ *
+ *  @note In the majority of situations applications will not need to specify an access group to use with Twitter sessions.
+ *  This value is only needed if you plan to share credentials with another application that you control or if you are
+ *  using TwitterKit with an app extension.
+ */
+- (void)startWithConsumerKey:(NSString *)consumerKey consumerSecret:(NSString *)consumerSecret urlSchemeSuffix:(nullable NSString *)urlSchemeSuffix accessGroup:(nullable NSString *)accessGroup;
 
 /**
  *  The current version of this kit.

--- a/TwitterKit/TwitterKit/TWTRTwitter.m
+++ b/TwitterKit/TwitterKit/TWTRTwitter.m
@@ -137,10 +137,20 @@ static TWTRTwitter *sharedTwitter;
 
 - (void)startWithConsumerKey:(NSString *)consumerKey consumerSecret:(NSString *)consumerSecret
 {
-    [self startWithConsumerKey:consumerKey consumerSecret:consumerSecret accessGroup:nil];
+    [self startWithConsumerKey:consumerKey consumerSecret:consumerSecret urlSchemeSuffix:nil accessGroup:nil];
+}
+
+- (void)startWithConsumerKey:(NSString *)consumerKey consumerSecret:(NSString *)consumerSecret urlSchemeSuffix:(nullable NSString *)urlSchemeSuffix
+{
+    [self startWithConsumerKey:consumerKey consumerSecret:consumerSecret urlSchemeSuffix:urlSchemeSuffix accessGroup:nil];
 }
 
 - (void)startWithConsumerKey:(NSString *)consumerKey consumerSecret:(NSString *)consumerSecret accessGroup:(NSString *)accessGroup
+{
+    [self startWithConsumerKey:consumerKey consumerSecret:consumerSecret urlSchemeSuffix:nil accessGroup:accessGroup];
+}
+
+- (void)startWithConsumerKey:(NSString *)consumerKey consumerSecret:(NSString *)consumerSecret urlSchemeSuffix:(nullable NSString *)urlSchemeSuffix accessGroup:(NSString *)accessGroup
 {
     if (self.isInitialized) {
         return;
@@ -153,7 +163,7 @@ static TWTRTwitter *sharedTwitter;
     [self ensureResourcesBundleExists];
     [self setupAPIServiceConfigs];
 
-    self->_authConfig = [[TWTRAuthConfig alloc] initWithConsumerKey:consumerKey consumerSecret:consumerSecret];
+    self->_authConfig = [[TWTRAuthConfig alloc] initWithConsumerKey:consumerKey consumerSecret:consumerSecret urlSchemeSuffix: urlSchemeSuffix];
 
     NSString *cacheDir = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) firstObject];
 


### PR DESCRIPTION
Supports the custom suffix of callback url scheme to use same Twitter-app in multi iOS application.

default supported url scheme:
`twitter-#{consumer-key}`

this pr:
`twitter-#{consumer-key}` or `twitter-#{consumer-key}#{custom suffix}`