### PR TITLE
Fix supported platforms in Info.plist

### DIFF
--- a/carthage-build.sh
+++ b/carthage-build.sh
@@ -14,6 +14,18 @@ TEMP_FRAMEWORK_PATH="${WORKING_DIR}/${MODULE_NAME}.xcframework.zip"
 cd "${WORKING_DIR}"
 
 carthage build --platform iOS --no-skip-current "${MODULE_NAME}" --use-xcframeworks
+
+# WORKAROUND: "TwitterCore.framework/Info.plist should specify CFBundleSupportedPlatforms with an array containing a single platform"
+# https://gist.github.com/pwc3/09b5dc326837e210b73daa63cd13503e
+# https://github.com/twilio/twilio-voice-ios/issues/64#issuecomment-747186499
+XCFRAMEWORK="$CART_DIR/Build/$MODULE_NAME.xcframework"
+INFO_PLIST="$XCFRAMEWORK/ios-arm64/$MODULE_NAME.framework/Info.plist"
+echo "Updating CFBundleSupportedPlatforms in $INFO_PLIST"
+plutil \
+    -replace CFBundleSupportedPlatforms \
+    -xml "<array><string>iPhoneOS</string></array>" \
+    "$INFO_PLIST"
+
 (cd $CART_DIR/Build; zip -r $TEMP_FRAMEWORK_PATH $MODULE_NAME.xcframework)
 
 if [ ! -f "${TEMP_FRAMEWORK_PATH}" ]; then


### PR DESCRIPTION
```
error: exportArchive: TwitterCore.framework/Info.plist should specify CFBundleSupportedPlatforms with an array containing a single platform, e.g. CFBundleSupportedPlatforms = [ iPhoneOS ], but it has CFBundleSupportedPlatforms = ["iPhoneOS", "iPhoneSimulator"]

AppThinning.StubError(errorDescription: Optional("TwitterCore.framework/Info.plist should specify CFBundleSupportedPlatforms with an array containing a single platform, e.g. CFBundleSupportedPlatforms = [ iPhoneOS ], but it has CFBundleSupportedPlatforms = [\"iPhoneOS\", \"iPhoneSimulator\"]"))
```